### PR TITLE
refine operation model

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9e2868dea387c6e758dd6ce1fddd7927e663e784020aa9707f1853c8d17425c4",
+  "originHash" : "3c998e1ad931be3a8177a98ee43f8da8342af4398e5c45f20a7c48c021d7c5ad",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "78c0dd739df8cb9ee14a8bbbf770facc4fc3402a",
         "version" : "4.15.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "729e01bc9b9dab466ac85f21fb9ee2bc1c61b258",
+        "version" : "1.8.4"
       }
     },
     {
@@ -191,6 +200,24 @@
       }
     },
     {
+      "identity" : "swift-bases",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-bases.git",
+      "state" : {
+        "revision" : "b5fb3260b0a2020d17700fbf496e4f9bba5e673e",
+        "version" : "0.0.4"
+      }
+    },
+    {
+      "identity" : "swift-cid",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-cid.git",
+      "state" : {
+        "revision" : "8af5d9de451ceaf45a42e9d6784054d8f5fa3544",
+        "version" : "0.0.4"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -233,6 +260,33 @@
       "state" : {
         "revision" : "e0165b53d49b413dd987526b641e05e246782685",
         "version" : "2.5.0"
+      }
+    },
+    {
+      "identity" : "swift-multibase",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-multibase.git",
+      "state" : {
+        "revision" : "41f436aa7389481bc01ee0cd032b422acd1ffd16",
+        "version" : "0.0.3"
+      }
+    },
+    {
+      "identity" : "swift-multicodec",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-multicodec.git",
+      "state" : {
+        "revision" : "bcc70e2debd98348546133abb50270e13b3da87d",
+        "version" : "0.0.8"
+      }
+    },
+    {
+      "identity" : "swift-multihash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-multihash.git",
+      "state" : {
+        "revision" : "7ea5a9866bd341601fa61647d521880944139353",
+        "version" : "0.0.4"
       }
     },
     {
@@ -305,6 +359,15 @@
       "state" : {
         "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
         "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "swift-varint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-varint.git",
+      "state" : {
+        "revision" : "1ea4cd2ea5f1c74527600de659f0805d2e12fa6b",
+        "version" : "0.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,8 @@ let package = Package(
     .package(url: "https://github.com/vapor/queues.git", from: "1.15.0"),
     .package(url: "https://github.com/vapor/queues-redis-driver.git", from: "1.0.0"),
     .package(url: "https://github.com/vapor/leaf.git", from: "4.0.0"),
+    .package(url: "https://github.com/swift-libp2p/swift-bases.git", from: "0.0.4"),
+    .package(url: "https://github.com/swift-libp2p/swift-cid.git", from: "0.0.4"),
   ],
   targets: [
     // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -27,6 +29,8 @@ let package = Package(
         .product(name: "QueuesRedisDriver", package: "queues-redis-driver"),
         .product(name: "Leaf", package: "leaf"),
         .product(name: "Vapor", package: "vapor"),
+        .product(name: "Base32", package: "swift-bases"),
+        .product(name: "CID", package: "swift-cid"),
       ],
       path: "Sources",
       swiftSettings: [

--- a/Sources/Migrations/CreateDidPlcsTable.swift
+++ b/Sources/Migrations/CreateDidPlcsTable.swift
@@ -1,0 +1,35 @@
+import Fluent
+
+struct CreateDidPlcsTable: AsyncMigration {
+  func prepare(on database: Database) async throws {
+    try await database.transaction { transaction in
+      let banReason = try await transaction.enum("ban_reason").read()
+      try await transaction.schema("did_plcs")
+        .field("id", .custom("BIT(120)"), .identifier(auto: false))
+        .field("banned", .bool, .required, .sql(.default(false)))
+        .field("reason", banReason)
+        .create()
+
+      var lastID: String? = nil
+      while true {
+        let query = Did.query(on: transaction).sort(\.$id).limit(64)
+        if let lastID {
+          query.filter(\.$id > lastID)
+        }
+        let dids = try await query.all()
+        if dids.isEmpty { break }
+        for did in dids {
+          try await DidPlc(
+            .init(didString: did.requireID()), banned: did.banned, reason: did.reason
+          )
+          .create(on: transaction)
+        }
+        lastID = dids.last?.id
+      }
+    }
+  }
+
+  func revert(on database: Database) async throws {
+    try await database.schema("did_plcs").delete()
+  }
+}

--- a/Sources/Migrations/CreateDidPlcsTable.swift
+++ b/Sources/Migrations/CreateDidPlcsTable.swift
@@ -1,11 +1,15 @@
 import Fluent
+import FluentSQL
 
 struct CreateDidPlcsTable: AsyncMigration {
   func prepare(on database: Database) async throws {
     try await database.transaction { transaction in
       let banReason = try await transaction.enum("ban_reason").read()
       try await transaction.schema("did_plcs")
-        .field("id", .custom("BIT(120)"), .identifier(auto: false))
+        .field(
+          "id", .custom("BYTEA"), .identifier(auto: false),
+          .sql(.check(SQLRaw("octet_length(id) = 15")))
+        )
         .field("banned", .bool, .required, .sql(.default(false)))
         .field("reason", banReason)
         .create()

--- a/Sources/Migrations/MergeBannedDidsTableToDidsTable.swift
+++ b/Sources/Migrations/MergeBannedDidsTableToDidsTable.swift
@@ -6,7 +6,7 @@ struct MergeBannedDidsTableToDidsTable: AsyncMigration {
     try await database.transaction { transaction in
       let banReason = try await transaction.enum("ban_reason").read()
       try await transaction.schema("dids")
-        .field("banned", .bool, .required, .custom("DEFAULT false"))
+        .field("banned", .bool, .required, .sql(.default(false)))
         .field("reason", banReason)
         .update()
       guard let sql = transaction as? SQLDatabase else {

--- a/Sources/Models/DidPlc.swift
+++ b/Sources/Models/DidPlc.swift
@@ -1,0 +1,60 @@
+import Base32
+import Fluent
+import Vapor
+
+final class DidPlc: Model, @unchecked Sendable {
+  static let schema = "did_plcs"
+
+  struct SpecificId: Codable, Hashable, Sendable {
+    let raw: Data
+
+    init(raw: Data) throws {
+      guard raw.count == 15 else {
+        throw FluentError.invalidField(name: "id", valueType: Self.self, error: "Invalid length")
+      }
+      self.raw = raw
+    }
+  }
+
+  @ID(custom: .id, generatedBy: .user)
+  var id: SpecificId?
+
+  @Field(key: "banned")
+  var banned: Bool
+
+  @OptionalEnum(key: "reason")
+  var reason: BanReason?
+
+  init() {}
+
+  init(_ id: SpecificId, banned: Bool = false, reason: BanReason? = nil) {
+    self.id = id
+    self.banned = banned
+    if banned {
+      self.reason = reason ?? .incompatibleAtproto
+    }
+  }
+}
+
+extension DidPlc.SpecificId {
+  var specificId: String {
+    Base32.encode(self.raw)
+  }
+
+  var didString: String {
+    "did:plc:\(self.specificId)"
+  }
+
+  init(specificId: String) throws {
+    let data = try Base32.decode(specificId)
+    try self.init(raw: data)
+  }
+
+  init(didString value: String) throws {
+    guard value.hasPrefix("did:plc:") else {
+      throw FluentError.invalidField(name: "id", valueType: Self.self, error: "Invalid format")
+    }
+    let specificId = String(value.dropFirst("did:plc:".count))
+    try self.init(specificId: specificId)
+  }
+}


### PR DESCRIPTION
- save did-method-plc's specific id binary (15 bytes, ~~`BIT(120)`~~ `BYTEA CHECK (octet_length() = 15)`) instead of did string
- save plc operation's cid hash binary (32 bytes, ~~`BIT(256)`~~ `BYTEA CHECK (octet_length() = 32)`) instead of cid base32 encoded value
  - always CIDv1, dag-cbor, SHA-256. prefix `bafyrei`
- save only diff